### PR TITLE
Fix table name in push notification function

### DIFF
--- a/supabase/functions/send-push-notification/index.ts
+++ b/supabase/functions/send-push-notification/index.ts
@@ -34,7 +34,7 @@ serve(async (req) => {
 
     // Get pending push notifications
     const { data: pushQueue, error: queueError } = await supabase
-      .from('notification_push_queue')
+      .from('push_queue')
       .select(
         `
         *,
@@ -107,7 +107,7 @@ serve(async (req) => {
 
         // Update queue status
         await supabase
-          .from('notification_push_queue')
+          .from('push_queue')
           .update({
             status: 'sent',
             sent_at: new Date().toISOString(),
@@ -140,7 +140,7 @@ serve(async (req) => {
 
         // Update queue status to failed
         await supabase
-          .from('notification_push_queue')
+          .from('push_queue')
           .update({
             status: 'failed',
             error_message: error.message,


### PR DESCRIPTION
Correct table name reference in `send-push-notification` edge function to fix push notification processing.