### PR TITLE
Fix notification delivery column names

### DIFF
--- a/supabase/functions/send-email-notification/index.ts
+++ b/supabase/functions/send-email-notification/index.ts
@@ -116,8 +116,8 @@ serve(async (req) => {
         await supabase
           .from('notification_deliveries')
           .update({
-            email_sent_at: new Date().toISOString(),
-            email_status: 'sent',
+            delivered_at: new Date().toISOString(),
+            status: 'sent',
           })
           .eq('notification_id', email.notification_id)
           .eq('user_id', email.user_id);

--- a/supabase/functions/send-push-notification/index.ts
+++ b/supabase/functions/send-push-notification/index.ts
@@ -118,8 +118,8 @@ serve(async (req) => {
         await supabase
           .from('notification_deliveries')
           .update({
-            push_sent_at: new Date().toISOString(),
-            push_status: 'sent',
+            delivered_at: new Date().toISOString(),
+            status: 'sent',
           })
           .eq('notification_id', pushItem.notification_id)
           .eq('user_id', notification.user_id);


### PR DESCRIPTION
Fix Supabase functions to use correct column names for `notification_deliveries` table updates.