### PR TITLE
Fix organization invite flow for removed users

### DIFF
--- a/ORGANIZATION_INVITATION_FEATURE_PLAN.md
+++ b/ORGANIZATION_INVITATION_FEATURE_PLAN.md
@@ -415,5 +415,27 @@ Implemented database-driven invitation linking system to make invitation flow mo
 4. **Automatic redirect** → User is taken to their pending invitation(s)
 5. **Reliable flow** → Works regardless of how user accesses the app (direct login, browser refresh, etc.)
 
-### 🎯 Next Priority: Apply Migration & Test
-Ready to apply the database migration and test the enhanced invitation system. 
+### 🎯 Recently Fixed: Previously Removed Users Issue ✅
+**Fixed critical bug where previously removed users couldn't be re-invited**
+
+#### ✅ **Issue Resolved**
+- **Problem**: Users with `status = 'deactivated'` (previously removed) couldn't be re-invited
+- **Root Cause**: Database functions only checked for `status = 'active'` memberships
+- **Impact**: Invitation flow would fail silently or cause constraint violations
+
+#### ✅ **Solution Implemented**
+- **Migration**: `20250707091451_fix_organization_invite_previously_removed_users.sql`
+- **Enhanced Functions**:
+  - `invite_user_to_organization_by_email()` - Now handles deactivated memberships
+  - `accept_organization_invitation()` - Reactivates deactivated memberships instead of creating duplicates
+- **Better UX**: Enhanced messaging for previously removed users
+- **Data Integrity**: Preserves audit trail while enabling reactivation
+
+#### ✅ **New Features Added**
+- **Enhanced return values** with `was_previously_member` and `was_reactivated` flags
+- **Contextual messaging** ("Invitation sent to previously removed user")
+- **Proper reactivation** instead of creating duplicate memberships
+- **Comprehensive error handling** for all membership states
+
+### 🎯 Next Priority: Apply Migration & Test Enhanced System
+Ready to apply the database migration and test the complete invitation system with the previously removed users fix. 

--- a/ORGANIZATION_INVITE_FIX.md
+++ b/ORGANIZATION_INVITE_FIX.md
@@ -1,0 +1,236 @@
+# Organization Invite Flow Fix for Previously Removed Users
+
+## Problem Statement
+
+The organization invitation system had a critical bug where users who were previously removed from an organization (status = `'deactivated'`) could not be re-invited. This occurred because:
+
+1. **Invitation Function Issue**: The `invite_user_to_organization_by_email` function only checked for active members (`status = 'active'`) but didn't handle users with `status = 'deactivated'`
+2. **Acceptance Function Issue**: The `accept_organization_invitation` function tried to INSERT new memberships instead of reactivating existing deactivated ones, potentially causing constraint violations
+
+## Root Cause Analysis
+
+### 1. Invitation Flow (`invite_user_to_organization_by_email`)
+
+**Original problematic code:**
+```sql
+-- Check if user is already a member
+IF EXISTS (
+  SELECT 1 FROM public.organization_users
+  WHERE organization_id = p_organization_id
+  AND user_id = v_existing_user_id
+  AND status = 'active'  -- Only checked for active users!
+) THEN
+  RETURN jsonb_build_object(
+    'success', FALSE,
+    'error', 'User is already a member of this organization',
+    'error_code', 'ALREADY_MEMBER'
+  );
+END IF;
+```
+
+**Issue**: This check ignored users with `status = 'deactivated'`, so invitations could be created but the acceptance flow would fail.
+
+### 2. Acceptance Flow (`accept_organization_invitation`)
+
+**Original problematic code:**
+```sql
+-- Check if user is already a member
+SELECT * INTO v_existing_membership
+FROM public.organization_users
+WHERE organization_id = v_invitation.organization_id
+AND user_id = v_user_id
+AND status = 'active';  -- Only looked for active members
+
+-- Later: Always tried to INSERT new membership
+INSERT INTO public.organization_users (...)
+```
+
+**Issue**: This would try to INSERT a new membership record even if a deactivated one existed, causing potential constraint violations.
+
+## Solution Implemented
+
+I've created a migration file: `supabase/migrations/20250707091451_fix_organization_invite_previously_removed_users.sql`
+
+### Key Changes
+
+#### 1. Enhanced `invite_user_to_organization_by_email`
+
+- **Now checks for ANY existing membership** (active, deactivated, pending)
+- **Handles all membership states appropriately**:
+  - `'active'` → Return error (already member)
+  - `'pending'` → Return error (pending invitation exists)
+  - `'deactivated'` → Allow new invitation (will be reactivated on acceptance)
+- **Provides better feedback** with `was_previously_member` flag and contextual messages
+
+#### 2. Enhanced `accept_organization_invitation`
+
+- **Reactivates deactivated memberships** instead of creating new ones
+- **Handles all existing membership scenarios**:
+  - `'active'` → Mark invitation accepted, return error
+  - `'deactivated'` → Reactivate membership with new role
+  - `'pending'` → Convert to active
+  - No membership → Create new one
+- **Provides better feedback** with `was_reactivated` flag
+
+### New Features Added
+
+#### Enhanced Return Values
+
+**Invitation function now returns:**
+```json
+{
+  "success": true,
+  "user_exists": true,
+  "token": "uuid-token",
+  "invitation_id": 123,
+  "was_previously_member": true,  // NEW
+  "message": "Invitation sent to previously removed user"  // ENHANCED
+}
+```
+
+**Acceptance function now returns:**
+```json
+{
+  "success": true,
+  "organization_id": 456,
+  "role": "member",
+  "message": "Invitation accepted successfully - membership reactivated",  // ENHANCED
+  "was_reactivated": true  // NEW
+}
+```
+
+## Implementation Details
+
+### Database Changes
+
+1. **No schema changes** - uses existing tables and columns
+2. **Backward compatible** - existing functionality unchanged
+3. **Enhanced logic** - better handling of edge cases
+
+### User Experience Improvements
+
+1. **Clear messaging** when inviting previously removed users
+2. **Proper reactivation** of memberships on acceptance
+3. **Audit trail preserved** - keeps historical data intact
+4. **Role updates** - invitation role is applied when reactivating
+
+## How to Apply the Fix
+
+### Option 1: Direct Migration Application
+
+If you have Supabase CLI linked to your project:
+
+```bash
+npx supabase db push
+```
+
+### Option 2: Manual Application
+
+1. **Connect to your Supabase database** (Dashboard → Database → SQL Editor)
+2. **Copy the contents** of `supabase/migrations/20250707091451_fix_organization_invite_previously_removed_users.sql`
+3. **Execute the migration** in the SQL Editor
+
+### Option 3: Production Deployment
+
+If using automated deployments:
+```bash
+# The migration file is already created and will be applied on next deployment
+git add supabase/migrations/20250707091451_fix_organization_invite_previously_removed_users.sql
+git commit -m "Fix organization invite flow for previously removed users"
+git push origin main
+```
+
+## Testing the Fix
+
+### Test Scenario 1: Invite Previously Removed User
+
+1. **Remove a user** from an organization (their status becomes `'deactivated'`)
+2. **Try to re-invite** the same user
+3. **Expected result**: Invitation should be sent successfully with message "Invitation sent to previously removed user"
+
+### Test Scenario 2: Accept Invitation as Previously Removed User
+
+1. **User accepts the invitation** via email link
+2. **Expected result**: Membership should be reactivated with message "Invitation accepted successfully - membership reactivated"
+3. **Verify**: User should have `status = 'active'` and the new role from the invitation
+
+### Test Scenario 3: UI Verification
+
+1. **Check the members page** after reactivation
+2. **Expected result**: User should appear in active members list, not pending invitations
+3. **Verify**: User should have access to the organization immediately
+
+## Monitoring and Verification
+
+### Database Queries to Verify Fix
+
+**Check for deactivated users who can be re-invited:**
+```sql
+SELECT 
+  ou.id,
+  ou.user_id,
+  ou.organization_id,
+  ou.status,
+  ou.left_at,
+  up.email
+FROM organization_users ou
+JOIN user_profiles up ON up.id = ou.user_id
+WHERE ou.status = 'deactivated'
+ORDER BY ou.left_at DESC;
+```
+
+**Check invitation acceptance success:**
+```sql
+SELECT 
+  oi.email,
+  oi.status,
+  oi.accepted_at,
+  ou.status as membership_status,
+  ou.role
+FROM organization_invitations oi
+LEFT JOIN organization_users ou ON ou.organization_id = oi.organization_id 
+  AND ou.user_id IN (
+    SELECT id FROM auth.users WHERE email = oi.email
+  )
+WHERE oi.status = 'accepted'
+ORDER BY oi.accepted_at DESC;
+```
+
+## Benefits of This Fix
+
+1. **Resolves the core issue** - Previously removed users can now be re-invited
+2. **Maintains data integrity** - No duplicate memberships created
+3. **Preserves audit trail** - Historical membership data kept
+4. **Better user experience** - Clear messaging and smooth flow
+5. **Backward compatible** - No breaking changes to existing functionality
+
+## Error Handling
+
+The fix includes comprehensive error handling for:
+
+- **Authentication issues** - Clear auth required messages
+- **Permission problems** - Proper role-based access control
+- **Invalid invitations** - Expired/invalid token handling
+- **Rate limiting** - Existing rate limits preserved
+- **Constraint violations** - Prevented through proper logic flow
+
+## Security Considerations
+
+- **No security regressions** - All existing security checks maintained
+- **Role validation** - Proper role hierarchy enforcement
+- **Permission checks** - Only admins/owners can invite users
+- **Rate limiting** - Existing protections remain in place
+
+---
+
+## Summary
+
+This fix resolves the critical issue where previously removed users couldn't be re-invited to organizations. The solution:
+
+1. ✅ **Handles deactivated memberships** properly
+2. ✅ **Reactivates memberships** instead of creating duplicates  
+3. ✅ **Provides better user feedback** with enhanced messaging
+4. ✅ **Maintains backward compatibility** with existing functionality
+5. ✅ **Preserves data integrity** and audit trails
+
+The migration is ready to apply and will immediately fix the organization invite flow for previously removed users.

--- a/supabase/migrations/20250707091451_fix_organization_invite_previously_removed_users.sql
+++ b/supabase/migrations/20250707091451_fix_organization_invite_previously_removed_users.sql
@@ -1,0 +1,328 @@
+-- ========================================
+-- FIX ORGANIZATION INVITE FLOW FOR PREVIOUSLY REMOVED USERS
+-- ========================================
+-- This migration fixes the issue where users who have been previously removed 
+-- from an organization (status = 'deactivated') cannot be re-invited.
+
+-- Updated function to invite user by email - handles previously removed users
+CREATE OR REPLACE FUNCTION public.invite_user_to_organization_by_email(
+  p_organization_id INTEGER,
+  p_email TEXT,
+  p_role TEXT
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_caller_id UUID := auth.uid();
+  v_caller_membership RECORD;
+  v_user_exists BOOLEAN;
+  v_existing_user_id UUID;
+  v_existing_invitation RECORD;
+  v_existing_membership RECORD;
+  v_invitation_id INTEGER;
+  v_token UUID;
+BEGIN
+  -- Caller must be authenticated
+  IF v_caller_id IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'Authentication required',
+      'error_code', 'AUTH_REQUIRED'
+    );
+  END IF;
+
+  -- Check if caller has permission to invite members
+  SELECT * INTO v_caller_membership
+  FROM public.organization_users
+  WHERE organization_id = p_organization_id
+  AND user_id = v_caller_id
+  AND role IN ('owner', 'admin')
+  AND status = 'active';
+  
+  IF v_caller_membership IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'Permission denied. You must be an owner or admin to invite users.',
+      'error_code', 'PERMISSION_DENIED'
+    );
+  END IF;
+
+  -- Validate role
+  IF p_role NOT IN ('owner', 'admin', 'member', 'guest') THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'Invalid role. Role must be one of: owner, admin, member, guest',
+      'error_code', 'INVALID_ROLE'
+    );
+  END IF;
+
+  -- Prevent non-owners from creating owners
+  IF p_role = 'owner' AND v_caller_membership.role != 'owner' THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'Only owners can create other owners',
+      'error_code', 'PERMISSION_DENIED'
+    );
+  END IF;
+
+  -- Check if user exists
+  v_user_exists := public.check_user_exists_by_email(p_email);
+  
+  IF v_user_exists THEN
+    v_existing_user_id := public.get_user_id_by_email(p_email);
+    
+    -- Check for ANY existing membership (active, deactivated, pending)
+    SELECT * INTO v_existing_membership
+    FROM public.organization_users
+    WHERE organization_id = p_organization_id
+    AND user_id = v_existing_user_id;
+    
+    IF v_existing_membership IS NOT NULL THEN
+      -- If user is already active, return error
+      IF v_existing_membership.status = 'active' THEN
+        RETURN jsonb_build_object(
+          'success', FALSE,
+          'error', 'User is already a member of this organization',
+          'error_code', 'ALREADY_MEMBER'
+        );
+      END IF;
+      
+      -- If user is pending, check for existing invitation
+      IF v_existing_membership.status = 'pending' THEN
+        RETURN jsonb_build_object(
+          'success', FALSE,
+          'error', 'User already has a pending invitation to this organization',
+          'error_code', 'PENDING_INVITATION'
+        );
+      END IF;
+      
+      -- If user was deactivated (previously removed), we can create a new invitation
+      -- The invitation system will handle reactivating their membership
+    END IF;
+  END IF;
+
+  -- Check for existing pending invitation
+  SELECT * INTO v_existing_invitation
+  FROM public.organization_invitations
+  WHERE organization_id = p_organization_id
+  AND email = p_email
+  AND status = 'pending'
+  AND expires_at > NOW();
+  
+  IF v_existing_invitation IS NOT NULL THEN
+    -- Check rate limiting for resends
+    IF v_existing_invitation.resend_count >= 3
+    AND v_existing_invitation.last_resend_at > (NOW() - INTERVAL '1 day') THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'Maximum resend limit reached. Please wait 24 hours before resending.',
+        'error_code', 'RATE_LIMIT_EXCEEDED'
+      );
+    END IF;
+
+    -- Update existing invitation (resend)
+    UPDATE public.organization_invitations
+    SET 
+      role = p_role,
+      resend_count = CASE
+        WHEN last_resend_at > (NOW() - INTERVAL '1 day') THEN resend_count + 1
+        ELSE 1
+      END,
+      last_resend_at = NOW(),
+      expires_at = NOW() + INTERVAL '7 days',
+      updated_at = NOW()
+    WHERE id = v_existing_invitation.id
+    RETURNING id, token INTO v_invitation_id, v_token;
+  ELSE
+    -- Create new invitation
+    INSERT INTO public.organization_invitations (
+      organization_id,
+      email,
+      role,
+      invited_by,
+      resend_count
+    ) VALUES (
+      p_organization_id,
+      p_email,
+      p_role,
+      v_caller_id,
+      0
+    ) RETURNING id, token INTO v_invitation_id, v_token;
+  END IF;
+
+  -- Return success response
+  RETURN jsonb_build_object(
+    'success', TRUE,
+    'user_exists', v_user_exists,
+    'token', v_token,
+    'invitation_id', v_invitation_id,
+    'was_previously_member', (v_existing_membership IS NOT NULL AND v_existing_membership.status = 'deactivated'),
+    'message', CASE 
+      WHEN v_existing_invitation IS NOT NULL THEN 'Invitation resent successfully'
+      WHEN v_existing_membership IS NOT NULL AND v_existing_membership.status = 'deactivated' THEN 'Invitation sent to previously removed user'
+      ELSE 'Invitation sent successfully'
+    END
+  );
+END;
+$$;
+
+-- Updated function to accept invitation - handles reactivating deactivated memberships
+CREATE OR REPLACE FUNCTION public.accept_organization_invitation(p_token UUID)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_invitation RECORD;
+  v_user_id UUID := auth.uid();
+  v_existing_membership RECORD;
+BEGIN
+  -- Must be authenticated to accept invitation
+  IF v_user_id IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'Authentication required to accept invitation',
+      'error_code', 'AUTH_REQUIRED'
+    );
+  END IF;
+
+  -- Get invitation details
+  SELECT * INTO v_invitation
+  FROM public.organization_invitations
+  WHERE token = p_token
+  AND status = 'pending'
+  AND expires_at > NOW();
+  
+  IF v_invitation IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'Invalid or expired invitation',
+      'error_code', 'INVALID_INVITATION'
+    );
+  END IF;
+
+  -- Check for ANY existing membership (active, deactivated, pending)
+  SELECT * INTO v_existing_membership
+  FROM public.organization_users
+  WHERE organization_id = v_invitation.organization_id
+  AND user_id = v_user_id;
+  
+  IF v_existing_membership IS NOT NULL THEN
+    -- If user is already active, mark invitation as accepted and return error
+    IF v_existing_membership.status = 'active' THEN
+      UPDATE public.organization_invitations
+      SET 
+        status = 'accepted',
+        accepted_at = NOW(),
+        updated_at = NOW()
+      WHERE id = v_invitation.id;
+      
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'You are already a member of this organization',
+        'error_code', 'ALREADY_MEMBER'
+      );
+    END IF;
+
+    -- If user has a deactivated membership, reactivate it
+    IF v_existing_membership.status = 'deactivated' THEN
+      UPDATE public.organization_users
+      SET 
+        status = 'active',
+        role = v_invitation.role,
+        joined_at = NOW(),
+        last_accessed_at = NOW(),
+        left_at = NULL,
+        updated_at = NOW()
+      WHERE id = v_existing_membership.id;
+      
+      -- Mark invitation as accepted
+      UPDATE public.organization_invitations
+      SET 
+        status = 'accepted',
+        accepted_at = NOW(),
+        updated_at = NOW()
+      WHERE id = v_invitation.id;
+
+      -- Switch user's current organization context
+      PERFORM public.switch_organization_context(v_invitation.organization_id);
+
+      RETURN jsonb_build_object(
+        'success', TRUE,
+        'organization_id', v_invitation.organization_id,
+        'role', v_invitation.role,
+        'message', 'Invitation accepted successfully - membership reactivated',
+        'was_reactivated', TRUE
+      );
+    END IF;
+
+    -- If user has a pending membership, update it to active
+    IF v_existing_membership.status = 'pending' THEN
+      UPDATE public.organization_users
+      SET 
+        status = 'active',
+        role = v_invitation.role,
+        joined_at = NOW(),
+        last_accessed_at = NOW(),
+        updated_at = NOW()
+      WHERE id = v_existing_membership.id;
+      
+      -- Mark invitation as accepted
+      UPDATE public.organization_invitations
+      SET 
+        status = 'accepted',
+        accepted_at = NOW(),
+        updated_at = NOW()
+      WHERE id = v_invitation.id;
+
+      -- Switch user's current organization context
+      PERFORM public.switch_organization_context(v_invitation.organization_id);
+
+      RETURN jsonb_build_object(
+        'success', TRUE,
+        'organization_id', v_invitation.organization_id,
+        'role', v_invitation.role,
+        'message', 'Invitation accepted successfully'
+      );
+    END IF;
+  END IF;
+
+  -- No existing membership, create new one
+  INSERT INTO public.organization_users (
+    organization_id,
+    user_id,
+    role,
+    status,
+    joined_at,
+    last_accessed_at,
+    notifications_enabled
+  ) VALUES (
+    v_invitation.organization_id,
+    v_user_id,
+    v_invitation.role,
+    'active',
+    NOW(),
+    NOW(),
+    TRUE
+  );
+
+  -- Mark invitation as accepted
+  UPDATE public.organization_invitations
+  SET 
+    status = 'accepted',
+    accepted_at = NOW(),
+    updated_at = NOW()
+  WHERE id = v_invitation.id;
+
+  -- Switch user's current organization context
+  PERFORM public.switch_organization_context(v_invitation.organization_id);
+
+  RETURN jsonb_build_object(
+    'success', TRUE,
+    'organization_id', v_invitation.organization_id,
+    'role', v_invitation.role,
+    'message', 'Invitation accepted successfully'
+  );
+END;
+$$;


### PR DESCRIPTION
Fix organization invite flow to allow re-inviting users previously removed from an organization.

The `invite_user_to_organization_by_email` function previously only checked for 'active' members, preventing re-invites for 'deactivated' users. Additionally, `accept_organization_invitation` would attempt to create a new membership instead of reactivating an existing 'deactivated' one, leading to failures.